### PR TITLE
Allow minimum succesful realizations to be zero

### DIFF
--- a/src/ropt/config/enopt/_realizations_config.py
+++ b/src/ropt/config/enopt/_realizations_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from pydantic import PositiveInt, model_validator
+from pydantic import NonNegativeInt, model_validator
 
 from ropt.config.utils import (
     Array1D,
@@ -61,7 +61,7 @@ class RealizationsConfig(EnOptBaseModel):
 
     names: Optional[UniqueNames] = None
     weights: Array1D = np.array(1.0)
-    realization_min_success: Optional[PositiveInt] = None
+    realization_min_success: Optional[NonNegativeInt] = None
 
     @model_validator(mode="after")
     def _broadcast_normalize_and_check(self) -> RealizationsConfig:

--- a/src/ropt/optimization/_optimizer.py
+++ b/src/ropt/optimization/_optimizer.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import numpy as np
 
 from ropt.enums import ConstraintType, OptimizerExitCode
-from ropt.exceptions import OptimizationAborted
+from ropt.exceptions import ConfigError, OptimizationAborted
 from ropt.results import (
     BoundConstraints,
     FunctionResults,
@@ -63,7 +63,15 @@ class Optimizer:
         *,
         return_functions: bool,
         return_gradients: bool,
+        allow_nan: bool = False,
     ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+        if (
+            self._enopt_config.realizations.realization_min_success < 1
+            and not allow_nan
+        ):
+            msg = "Failed function evaluations by the optimizer"
+            raise ConfigError(msg)
+
         assert return_functions or return_gradients
 
         self._check_stopping_criteria()

--- a/src/ropt/plugins/optimizer/protocol.py
+++ b/src/ropt/plugins/optimizer/protocol.py
@@ -34,6 +34,7 @@ class OptimizerCallback(Protocol):
         *,
         return_functions: bool,
         return_gradients: bool,
+        allow_nan: bool = False,
     ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
         """The signature of the optimizer callback.
 
@@ -46,8 +47,8 @@ class OptimizerCallback(Protocol):
         The `return_functions` and `return_gradients` flags determine whether
         functions and/or gradients are to be evaluated. The results are returned
         as a tuple of arrays, one for functions and constraints, the other for
-        gradients. If one of `return_functions` or `return_gradients` is `False`,
-        the corresponding result is an empty array.
+        gradients. If one of `return_functions` or `return_gradients` is
+        `False`, the corresponding result is an empty array.
 
         Multiple function evaluations are returned as a matrix where the rows
         are the result vectors for each evaluation. The first element of a
@@ -60,10 +61,17 @@ class OptimizerCallback(Protocol):
         the non-linear constraints. Gradient-based methods currently support
         only a single evaluation, hence there is also only a single result.
 
+        In most cases, the optimizer cannot handle failed function evaluations,
+        which are indicated by `NaN` values. Some optimizers, in particular
+        those that use multiple function evaluations do determine a next step
+        are robust in this regard. By returning `allow_nan=True`, these
+        optimizers can indicate that this is the case.
+
         Args:
-            variables:        The variable vector or matrix to evaluate.
-            return_functions: If `True`, evaluate and return functions.
-            return_gradients: If `True`, evaluate and return gradients.
+            variables:        The variable vector or matrix to evaluate
+            return_functions: If `True`, evaluate and return functions
+            return_gradients: If `True`, evaluate and return gradients
+            allow_nan:        If `True`, accept `NaN` values
 
         Returns:
             A tuple with function and gradient values.

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -129,6 +129,19 @@ def test_failed_realizations(enopt_config: Any, evaluator: Any) -> None:
     optimizer.start_optimization(plan=[{"config": enopt_config}, {"optimizer": {}}])
 
 
+def test_all_failed_realizations_not_supported(
+    enopt_config: Any, evaluator: Any
+) -> None:
+    enopt_config["realizations"] = {"realization_min_success": 0}
+
+    functions = [lambda _0, _1: np.array(1.0), lambda _0, _1: np.array(np.nan)]
+    optimizer = EnsembleOptimizer(evaluator(functions))
+    with pytest.raises(
+        ConfigError, match="Failed function evaluations by the optimizer"
+    ):
+        optimizer.start_optimization(plan=[{"config": enopt_config}, {"optimizer": {}}])
+
+
 def test_user_abort(enopt_config: Any, evaluator: Any) -> None:
     last_evaluation = 100
 


### PR DESCRIPTION
Some optimizers are robust to failed function evaluations. This PR makes it possible to set the minimum number of successful realizations to zero, and handles the case that all realizations  fail by return `NaN` values. Optimizers must in there function evaluation callback indicate if they can handle this. If so, they must take some action to mitigate the situation. Optimizers that do not indicate they can handle it will cause an error to be raised.