### PR TITLE
Rewrite approach to handle failures

### DIFF
--- a/src/ropt/config/enopt/_realizations_config.py
+++ b/src/ropt/config/enopt/_realizations_config.py
@@ -52,6 +52,12 @@ class RealizationsConfig(EnOptBaseModel):
     successful realizations. By default, it is set equal to the number of
     realizations, i.e., there are no missing values allowed by default.
 
+    Note:
+        The value of `realization_min_success` can be set to zero. Some
+        optimizers can handle this and will proceed with the optimization even
+        if all realizations fail. However, most optimizers cannot handle this
+        and will behave as if the value is set to one.
+
     Attributes:
         names:                   Optional names of the realizations
         weights:                 The weights of the realizations (default: 1)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -134,12 +134,13 @@ def test_all_failed_realizations_not_supported(
 ) -> None:
     enopt_config["realizations"] = {"realization_min_success": 0}
 
+    def handle_finished(event: OptimizationEvent) -> None:
+        assert event.exit_code == OptimizerExitCode.TOO_FEW_REALIZATIONS
+
     functions = [lambda _0, _1: np.array(1.0), lambda _0, _1: np.array(np.nan)]
     optimizer = EnsembleOptimizer(evaluator(functions))
-    with pytest.raises(
-        ConfigError, match="Failed function evaluations by the optimizer"
-    ):
-        optimizer.start_optimization(plan=[{"config": enopt_config}, {"optimizer": {}}])
+    optimizer.add_observer(EventType.FINISHED_OPTIMIZER_STEP, handle_finished)
+    optimizer.start_optimization(plan=[{"config": enopt_config}, {"optimizer": {}}])
 
 
 def test_user_abort(enopt_config: Any, evaluator: Any) -> None:


### PR DESCRIPTION
The previous approach to handle a minimum of zero for successful realizations was too restrictive. This changes the approach to only check if the optimizer handles this if that situation actually occurs. If not the optimization is aborted with a too few realizations error. The behavior should now be that optimizers that do not support it, behave like the  number is set to one.